### PR TITLE
Don't fail with elements with no children.

### DIFF
--- a/docdata/interface.py
+++ b/docdata/interface.py
@@ -155,7 +155,8 @@ class PaymentInterface(object):
             data = {}
             for e in resultdom.getElementsByTagName('status')[0].childNodes:
                 # Make sure we've got only one child
-                assert len(e.childNodes) == 1
+                if len(e.childNodes) != 1:
+                    continue
 
                 value = e.firstChild
 


### PR DESCRIPTION
Small bug fix if you're interested. Elements with no data can have no children (i.e. `<random_status_thing/>`) in which case they should be ignored.
